### PR TITLE
Ipasir solve final

### DIFF
--- a/app/genipasat/genipasat.c
+++ b/app/genipasat/genipasat.c
@@ -139,7 +139,11 @@ int main (int argc, char ** argv) {
   if (closefile == 2) pclose (file);
   if (closefile == 1) fclose (file);
   msg ("calling SAT solver after %.2f seconds", getime ());
+#if defined(IPASIR_VERSION) && IPASIR_VERSION >= 3
+  res = ipasir_solve_final (solver);
+#else
   res = ipasir_solve (solver);
+#endif
   msg ("SAT solver returns %d after %.2f seconds", res, getime ());
   fflush (stderr);
   if (res == 10) {

--- a/ipasir.h
+++ b/ipasir.h
@@ -62,12 +62,26 @@ void ipasir_assume (void * solver, int lit);
  * If the formula is satisfiable the function returns 10 and the state of the solver is changed to SAT.
  * If the formula is unsatisfiable the function returns 20 and the state of the solver is changed to UNSAT.
  * If the search is interrupted (see ipasir_set_terminate) the function returns 0 and the state of the solver remains INPUT.
- * This function can be called in any defined state of the solver.
+ * This function can be called in any defined state of the solver, except the function ipasir_solve_final has been called before.
  *
  * Required state: INPUT or SAT or UNSAT
  * State after: INPUT or SAT or UNSAT
  */
 int ipasir_solve (void * solver);
+
+/**
+ * Solve the formula with specified clauses under the specified assumptions.
+ * If the formula is satisfiable the function returns 10 and the state of the solver is changed to SAT.
+ * If the formula is unsatisfiable the function returns 20 and the state of the solver is changed to UNSAT.
+ * If the search is interrupted (see ipasir_set_terminate) the function returns 0 and the state of the solver remains INPUT.
+ * This function can be called in any defined state of the solver.
+ *
+ * After this function was called, the solver state is unsafe to be used with further calls to ipasir_solve.
+ *
+ * Required state: INPUT or SAT or UNSAT
+ * State after: SAT_NOSOLVE or UNSAT_NOSOLVE
+ */
+int ipasir_solve_final (void * solver);
 
 /**
  * Get the truth value of the given literal in the found satisfying

--- a/ipasir.h
+++ b/ipasir.h
@@ -4,6 +4,14 @@
 #ifndef ipasir_h_INCLUDED
 #define ipasir_h_INCLUDED
 
+/* Depending on the version of the interface, certain functions might not be
+ * supported by the SAT backend that implements the interface. Therefore, allow
+ * to control the version to be used via a macro.
+ */
+#ifndef IPASIR_VERSION
+#define IPASIR_VERSION 3
+#endif
+
 /**
  * Return the name and the version of the incremental SAT
  * solving library.
@@ -69,6 +77,7 @@ void ipasir_assume (void * solver, int lit);
  */
 int ipasir_solve (void * solver);
 
+#if defined(IPASIR_VERSION) && IPASIR_VERSION >= 3
 /**
  * Solve the formula with specified clauses under the specified assumptions.
  * If the formula is satisfiable the function returns 10 and the state of the solver is changed to SAT.
@@ -82,6 +91,7 @@ int ipasir_solve (void * solver);
  * State after: SAT_NOSOLVE or UNSAT_NOSOLVE
  */
 int ipasir_solve_final (void * solver);
+#endif /* IPASIR_VERSION >= 3 */
 
 /**
  * Get the truth value of the given literal in the found satisfying
@@ -123,6 +133,7 @@ int ipasir_failed (void * solver, int lit);
  */
 void ipasir_set_terminate (void * solver, void * state, int (*terminate)(void * state));
 
+#if defined(IPASIR_VERSION) && IPASIR_VERSION >= 2
 /**
  * Set a callback function used to extract learned clauses up to a given length from the
  * solver. The solver will call this function for each learned clause that satisfies
@@ -138,5 +149,6 @@ void ipasir_set_terminate (void * solver, void * state, int (*terminate)(void * 
  * State after: INPUT or SAT or UNSAT
  */
 void ipasir_set_learn (void * solver, void * state, int max_length, void (*learn)(void * state, int * clause));
+#endif /* IPASIR_VERSION >= 2 */
 
 #endif

--- a/sat/minisat220/makefile
+++ b/sat/minisat220/makefile
@@ -62,6 +62,7 @@ libipasir$(SIG).a: .FORCE
 	@#
 	sed -i -e 's,"\([=|]\),"c [${SIG}] \1,' $(DIR)/minisat/core/Main.cc
 	sed -i -e 's,"\([=|]\),"c [${SIG}] \1,' $(DIR)/minisat/core/Solver.cc
+	sed -i -e 's,"\([=|]\),"c [${SIG}] \1,' $(DIR)/minisat/simp/SimpSolver.cc
 	@#
 	@# configure and build library
 	@#
@@ -83,7 +84,8 @@ libipasir$(SIG).a: .FORCE
 ipasir$(NAME)glue.o: ipasir$(NAME)glue.cc ipasir.h makefile
 	$(CXX) $(CXXFLAGS) \
 	  -DVERSION=\"$(VERSION)\" \
-	  -I$(DIR) -I$(DIR)/minisat/core -c ipasir$(NAME)glue.cc
+	  -I$(DIR) -I$(DIR)/minisat/core \
+	  -I$(DIR)/minisat/simp -c ipasir$(NAME)glue.cc
 
 #-----------------------------------------------------------------------#
 


### PR DESCRIPTION
This is an RFC. I am happy to discuss whether there is another way to allow people to use simplification of solvers like MiniSat or Glucose without modifying those solvers.

In this example, only minisat220 can be used with the modified genipasat example binary. Before merging, the other solver backends should be extended accordingly.