### PR TITLE
Replace usage of int with int32_t where it denotes the type of a literal

### DIFF
--- a/ipasir.h
+++ b/ipasir.h
@@ -4,6 +4,8 @@
 #ifndef ipasir_h_INCLUDED
 #define ipasir_h_INCLUDED
 
+#include <stdint.h>
+
 /*
  * In this header, the macro IPASIR_API is defined as follows:
  * - if IPASIR_SHARED_LIB is not defined, then IPASIR_API is defined, but empty.
@@ -91,7 +93,7 @@ IPASIR_API void ipasir_release (void * solver);
  * negation overflow).  This applies to all the literal
  * arguments in API functions.
  */
-IPASIR_API void ipasir_add (void * solver, int lit_or_zero);
+IPASIR_API void ipasir_add (void * solver, int32_t lit_or_zero);
 
 /**
  * Add an assumption for the next SAT search (the next call
@@ -101,7 +103,7 @@ IPASIR_API void ipasir_add (void * solver, int lit_or_zero);
  * Required state: INPUT or SAT or UNSAT
  * State after: INPUT
  */
-IPASIR_API void ipasir_assume (void * solver, int lit);
+IPASIR_API void ipasir_assume (void * solver, int32_t lit);
 
 /**
  * Solve the formula with specified clauses under the specified assumptions.
@@ -129,7 +131,7 @@ IPASIR_API int ipasir_solve (void * solver);
  * Required state: SAT
  * State after: SAT
  */
-IPASIR_API int ipasir_val (void * solver, int lit);
+IPASIR_API int ipasir_val (void * solver, int32_t lit);
 
 /**
  * Check if the given assumption literal was used to prove the
@@ -146,7 +148,7 @@ IPASIR_API int ipasir_val (void * solver, int lit);
  * Required state: UNSAT
  * State after: UNSAT
  */
-IPASIR_API int ipasir_failed (void * solver, int lit);
+IPASIR_API int ipasir_failed (void * solver, int32_t lit);
 
 /**
  * Set a callback function used to indicate a termination requirement to the
@@ -177,7 +179,7 @@ IPASIR_API void ipasir_set_terminate (void * solver, void * data, int (*terminat
  * Required state: INPUT or SAT or UNSAT
  * State after: INPUT or SAT or UNSAT
  */
-IPASIR_API void ipasir_set_learn (void * solver, void * data, int max_length, void (*learn)(void * data, int * clause));
+IPASIR_API void ipasir_set_learn (void * solver, void * data, int max_length, void (*learn)(void * data, int32_t * clause));
 
 #ifdef __cplusplus
 } // closing extern "C"

--- a/sat/lingelingbcj/ipasirlingelingglue.cpp
+++ b/sat/lingelingbcj/ipasirlingelingglue.cpp
@@ -24,14 +24,14 @@ void ipasir_release(void* solver) {
 	lglrelease((LGL*)solver);
 }
 
-void ipasir_add(void* solver, int lit) {
+void ipasir_add(void* solver, int32_t lit) {
 	if (lit != 0) {
 		lglfreeze((LGL*)solver, lit);
 	}
 	lgladd((LGL*)solver, lit);
 }
 
-void ipasir_assume(void* solver, int lit) {
+void ipasir_assume(void* solver, int32_t lit) {
 	lglfreeze((LGL*)solver, lit);
 	lglassume((LGL*)solver, lit);
 }
@@ -40,11 +40,11 @@ int ipasir_solve(void* solver) {
 	return lglsat((LGL*)solver);
 }
 
-int ipasir_val(void * solver, int var) {
+int ipasir_val(void * solver, int32_t var) {
 	return var*lglderef((LGL*)solver, var);
 }
 
-int ipasir_failed(void * solver, int lit) {
+int ipasir_failed(void * solver, int32_t lit) {
 	return lglfailed((LGL*)solver, lit);
 }
 
@@ -52,6 +52,6 @@ void ipasir_set_terminate(void * solver,  void * state, int (*terminate)(void * 
 	lglseterm((LGL*)solver, terminate, state);
 }
 
-void ipasir_set_learn (void * solver, void * state, int max_length, void (*learn)(void * state, int * clause)) {
+void ipasir_set_learn (void * solver, void * state, int max_length, void (*learn)(void * state, int32_t * clause)) {
 	//not implemented
 }

--- a/sat/minisat220/ipasirminisatglue.cc
+++ b/sat/minisat220/ipasirminisatglue.cc
@@ -36,7 +36,7 @@ class IPAsirMiniSAT : public Solver {
   int szfmap; unsigned char * fmap; bool nomodel;
   unsigned long long calls;
   void reset () { if (fmap) delete [] fmap, fmap = 0, szfmap = 0; }
-  Lit import (int lit) { 
+  Lit import (int32_t lit) {
     while (abs (lit) > nVars ()) (void) newVar ();
     return mkLit (Var (abs (lit) - 1), (lit < 0));
   }
@@ -57,13 +57,13 @@ public:
     verbosity = 1;
   }
   ~IPAsirMiniSAT () { reset (); }
-  void add (int lit) {
+  void add (int32_t lit) {
     reset ();
     nomodel = true;
     if (lit) clause.push (import (lit));
     else addClause (clause), clause.clear ();
   }
-  void assume (int lit) {
+  void assume (int32_t lit) {
     reset ();
     nomodel = true;
     assumptions.push (import (lit));
@@ -76,12 +76,12 @@ public:
     nomodel = (res != l_True);
     return (res == l_Undef) ? 0 : (res == l_True ? 10 : 20);
   }
-  int val (int lit) {
+  int val (int32_t lit) {
     if (nomodel) return 0;
     lbool res = modelValue (import (lit));
     return (res == l_True) ? lit : -lit;
   }
-  int failed (int lit) {
+  int failed (int32_t lit) {
     if (!fmap) ana ();
     int tmp = var (import (lit));
     assert (0 <= tmp && tmp < nVars ());
@@ -115,10 +115,10 @@ const char * ipasir_signature () { return sig; }
 void * ipasir_init () { return new IPAsirMiniSAT (); }
 void ipasir_release (void * s) { import (s)->stats (); delete import (s); }
 int ipasir_solve (void * s) { return import (s)->solve (); }
-void ipasir_add (void * s, int l) { import (s)->add (l); }
-void ipasir_assume (void * s, int l) { import (s)->assume (l); }
-int ipasir_val (void * s, int l) { return import (s)->val (l); }
-int ipasir_failed (void * s, int l) { return import (s)->failed (l); }
+void ipasir_add (void * s, int32_t l) { import (s)->add (l); }
+void ipasir_assume (void * s, int32_t l) { import (s)->assume (l); }
+int ipasir_val (void * s, int32_t l) { return import (s)->val (l); }
+int ipasir_failed (void * s, int32_t l) { return import (s)->failed (l); }
 void ipasir_set_terminate (void * s, void * state, int (*callback)(void * state)) { import(s)->setTermCallback(state, callback); }
-void ipasir_set_learn (void * s, void * state, int max_length, void (*learn)(void * state, int * clause)) { import(s)->setLearnCallback(state, max_length, learn); }
+void ipasir_set_learn (void * s, void * state, int max_length, void (*learn)(void * state, int32_t * clause)) { import(s)->setLearnCallback(state, max_length, learn); }
 };

--- a/sat/picosat961/ipasirpicosatglue.c
+++ b/sat/picosat961/ipasirpicosatglue.c
@@ -20,17 +20,17 @@ void ipasir_release (void * solver) {
   picosat_reset (solver);
 }
 
-void ipasir_add (void * solver, int lit) { picosat_add (solver, lit); }
+void ipasir_add (void * solver, int32_t lit) { picosat_add (solver, lit); }
 
-void ipasir_assume (void * solver, int lit) { picosat_assume (solver, lit); }
+void ipasir_assume (void * solver, int32_t lit) { picosat_assume (solver, lit); }
 
 int ipasir_solve (void * solver) { return picosat_sat (solver, -1); }
 
-int ipasir_failed (void * solver, int lit) {
+int ipasir_failed (void * solver, int32_t lit) {
   return picosat_failed_assumption (solver, lit);
 }
 
-int ipasir_val (void * solver, int var) {
+int ipasir_val (void * solver, int32_t var) {
   int val = picosat_deref (solver, var);
   if (!val) return 0;
   return val < 0 ? -var : var;
@@ -44,5 +44,5 @@ ipasir_set_terminate (
 }
 
 /* Picosat does not implement clause sharing functionality */
-void ipasir_set_learn (void * solver, void * state, int max_length, void (*learn)(void * state, int * clause)) {}
+void ipasir_set_learn (void * solver, void * state, int max_length, void (*learn)(void * state, int32_t * clause)) {}
 


### PR DESCRIPTION
Currently IPASIR uses `int` whenever it denotes the type of a literal.

## Problem

This generally is not FFI friendly since `int` does not have a fixed size and could theoretically be anything between 16-bit to 64-bit. Practically it is 32-bit on most platforms but there is no guarantee.

If two programs compiled with different assumptions for the size of `int` were to communicate with each other over the IPASIR interface this would lead to failure.
Changing `int` to `int32_t` should not break IPASIR users since most (if not all) production ready solvers use 32-bit integers for their literal representation anyways. With this PR this information is now also encoded.

## Future Enhancementss

Even though it would make sense for IPASIR to only use fixed-sized integer types in general I did not replace any other types since the literal type notation is the most important at this point and also I wanted to keep the PR small and contained.

## Downsides

- One downside of using the standard C header `<stdint.h>` (with C++ it is `<cstdint>`) is that the type `int32_t` might not be available since it is marked as optional. However, in these cases we are on either an 8-bit or 16-bit platform and probably do not want to run a SAT solver anyways.
- This is a breaking change, however to my personal understanding it would only break in scenarios that are already broken due to the problem stated above or in cases where both client and solver use 64-bit literals so far.

----

My personal motivation for this to be merged is that I would feel far more confident with my IPASIR bindings from another language.