### PR TITLE
refer INT32_MAX and INT32_MIN instead of INT_MIN and INT_MAX as the limits of literals

### DIFF
--- a/ipasir.h
+++ b/ipasir.h
@@ -89,7 +89,7 @@ IPASIR_API void ipasir_release (void * solver);
  *
  * Literals are encoded as (non-zero) integers as in the
  * DIMACS formats.  They have to be smaller or equal to
- * INT_MAX and strictly larger than INT_MIN (to avoid
+ * INT32_MAX and strictly larger than INT32_MIN (to avoid
  * negation overflow).  This applies to all the literal
  * arguments in API functions.
  */


### PR DESCRIPTION
#18 adopted `int32_t` as the type of literals, so `INT32_MIN` and `INT32_MAX` are more appropriate than `INT_MIN` and `INT_MAX` as the limits of literal values.