### PR TITLE
change return type of ipasir_val to int32_t

### DIFF
--- a/ipasir.h
+++ b/ipasir.h
@@ -131,7 +131,7 @@ IPASIR_API int ipasir_solve (void * solver);
  * Required state: SAT
  * State after: SAT
  */
-IPASIR_API int ipasir_val (void * solver, int32_t lit);
+IPASIR_API int32_t ipasir_val (void * solver, int32_t lit);
 
 /**
  * Check if the given assumption literal was used to prove the


### PR DESCRIPTION
`ipasir_val`'s return value is a literal or `0`, so using `int32_t` rather than `int` is more consistent with #18.